### PR TITLE
Remove NoParam/NoResult overloads

### DIFF
--- a/lib/rx_command.dart
+++ b/lib/rx_command.dart
@@ -101,72 +101,6 @@ abstract class RxCommand<TParam, TResult> extends Observable<TResult> {
     });
   }
 
-  /// Creates  a RxCommand for a synchronous handler function with no parameter and no return type
-  /// [action]: handler function
-  /// [canExecute] : observable that can bve used to enable/diable the command based on some other state change
-  /// if omitted the command can be executed always except it's already executing
-  /// [isExecuting] will issue a `bool` value on each state change. Even if you
-  /// subscribe to a newly created command it will issue `false`
-  /// For the `Observable<CommandResult>` that [RxCommand] publishes in [results] this normally doesn't make sense
-  /// if you want to get an initial Result with `data==null, error==null, isExceuting==false` pass
-  /// [emitInitialCommandResult=true].
-  /// By default the [results] Observable and the [RxCommand] itself behave like a PublishSubject. If you want that it acts like
-  /// a BehaviourSubject, meaning every new listener gets the last received value, you can set [emitsLastValueToNewSubscriptions = true].
-  static RxCommand<void, void> createSyncNoParamNoResult(Action action,
-      {Observable<bool> canExecute,
-      bool emitInitialCommandResult = false,
-      bool emitsLastValueToNewSubscriptions = false}) {
-    return new RxCommandSync<void, void>((_) {
-      action();
-      return null;
-    }, canExecute, emitInitialCommandResult, false, emitsLastValueToNewSubscriptions, null);
-  }
-
-  /// Creates  a RxCommand for a synchronous handler function with one parameter and no return type
-  /// `action`: handler function
-  /// `canExecute` : observable that can bve used to enable/diable the command based on some other state change
-  /// if omitted the command can be executed always except it's already executing
-  /// [isExecuting] will issue a `bool` value on each state change. Even if you
-  /// subscribe to a newly created command it will issue `false`
-  /// For the `Observable<CommandResult>` that [RxCommand] publishes in [results]  this normally doesn't make sense
-  /// if you want to get an initial Result with `data==null, error==null, isExceuting==false` pass
-  /// [emitInitialCommandResult=true].
-  /// By default the [results] Observable and the [RxCommand] itself behave like a PublishSubject. If you want that it acts like
-  /// a BehaviourSubject, meaning every new listener gets the last received value, you can set [emitsLastValueToNewSubscriptions = true].
-  static RxCommand<TParam, void> createSyncNoResult<TParam>(Action1<TParam> action,
-      {Observable<bool> canExecute,
-      bool emitInitialCommandResult = false,
-      bool emitsLastValueToNewSubscriptions = false}) {
-    return new RxCommandSync<TParam, void>((x) {
-      action(x);
-      return null;
-    }, canExecute, emitInitialCommandResult, false, emitsLastValueToNewSubscriptions, null);
-  }
-
-  /// Creates  a RxCommand for a synchronous handler function with no parameter that returns a value
-  /// `func`: handler function
-  /// `canExecute` : observable that can bve used to enable/diable the command based on some other state change
-  /// if omitted the command can be executed always except it's already executing
-  /// [isExecuting] will issue a `bool` value on each state change. Even if you
-  /// subscribe to a newly created command it will issue `false`
-  /// [emitLastResult] will include the value of the last successful execution in all [CommandResult] events unless there is no new result.
-  /// For the `Observable<CommandResult>` that [RxCommand] publishes in [results]  this normally doesn't make sense
-  /// if you want to get an initial Result with `data==null, error==null, isExceuting==false` pass
-  /// [emitInitialCommandResult=true].
-  /// By default the [results] Observable and the [RxCommand] itself behave like a PublishSubject. If you want that it acts like
-  /// a BehaviourSubject, meaning every new listener gets the last received value, you can set [emitsLastValueToNewSubscriptions = true].
-  /// [initialLastResult] sets the value of the [lastResult] property before the first item was received. This is helpful if you use
-  /// [lastResult] as `initialData` of a `StreamBuilder`
-  static RxCommand<void, TResult> createSyncNoParam<TResult>(Func<TResult> func,
-      {Observable<bool> canExecute,
-      bool emitInitialCommandResult = false,
-      bool emitLastResult = false,
-      bool emitsLastValueToNewSubscriptions = false,
-      TResult initialLastResult}) {
-    return new RxCommandSync<void, TResult>((_) => func(), canExecute, emitInitialCommandResult, emitLastResult,
-        emitsLastValueToNewSubscriptions, initialLastResult);
-  }
-
   /// Creates  a RxCommand for a synchronous handler function with parameter that returns a value
   /// `func`: handler function
   /// `canExecute` : observable that can bve used to enable/diable the command based on some other state change
@@ -191,73 +125,7 @@ abstract class RxCommand<TParam, TResult> extends Observable<TResult> {
         emitsLastValueToNewSubscriptions, initialLastResult);
   }
 
-  // Assynchronous
-
-  /// Creates  a RxCommand for an asynchronous handler function with no parameter and no return type
-  /// `action`: handler function
-  /// `canExecute` : observable that can bve used to enable/diable the command based on some other state change
-  /// if omitted the command can be executed always except it's already executing
-  /// [isExecuting] will issue a `bool` value on each state change. Even if you
-  /// subscribe to a newly created command it will issue `false`
-  /// For the `Observable<CommandResult>` that [RxCommand] implement this normally doesn't make sense
-  /// if you want to get an initial Result with `data==null, error==null, isExceuting==false` pass
-  /// [emitInitialCommandResult=true].
-  /// By default the [results] Observable and the [RxCommand] itself behave like a PublishSubject. If you want that it acts like
-  /// a BehaviourSubject, meaning every new listener gets the last received value, you can set [emitsLastValueToNewSubscriptions = true].
-  static RxCommand<void, void> createAsyncNoParamNoResult(AsyncAction action,
-      {Observable<bool> canExecute,
-      bool emitInitialCommandResult = false,
-      bool emitsLastValueToNewSubscriptions = false}) {
-    return new RxCommandAsync<void, void>((_) async {
-      await action();
-      return null;
-    }, canExecute, emitInitialCommandResult, false, emitsLastValueToNewSubscriptions, null);
-  }
-
-  /// Creates  a RxCommand for an asynchronous handler function with one parameter and no return type
-  /// `action`: handler function
-  /// `canExecute` : observable that can bve used to enable/diable the command based on some other state change
-  /// if omitted the command can be executed always except it's already executing
-  /// [isExecuting] will issue a `bool` value on each state change. Even if you
-  /// subscribe to a newly created command it will issue `false`
-  /// For the `Observable<CommandResult>` that [RxCommand] implement this normally doesn't make sense
-  /// if you want to get an initial Result with `data==null, error==null, isExceuting==false` pass
-  /// [emitInitialCommandResult=true].
-  /// By default the [results] Observable and the [RxCommand] itself behave like a PublishSubject. If you want that it acts like
-  /// a BehaviourSubject, meaning every new listener gets the last received value, you can set [emitsLastValueToNewSubscriptions = true].
-  static RxCommand<TParam, void> createAsyncNoResult<TParam>(AsyncAction1<TParam> action,
-      {Observable<bool> canExecute,
-      bool emitInitialCommandResult = false,
-      bool emitsLastValueToNewSubscriptions = false}) {
-    return new RxCommandAsync<TParam, void>((x) async {
-      await action(x);
-      return null;
-    }, canExecute, emitInitialCommandResult, false, emitsLastValueToNewSubscriptions, null);
-  }
-
-  /// Creates  a RxCommand for an asynchronous handler function with no parameter that returns a value
-  /// `func`: handler function
-  /// `canExecute` : observable that can bve used to enable/diable the command based on some other state change
-  /// if omitted the command can be executed always except it's already executing
-  /// [isExecuting] will issue a `bool` value on each state change. Even if you
-  /// subscribe to a newly created command it will issue `false`
-  /// for the `Observable<CommandResult>` that [RxCommand] publishes in [results] this normally doesn't make sense
-  /// if you want to get an initial Result with `data==null, error==null, isExceuting==false` pass
-  /// [emitInitialCommandResult=true].
-  /// [emitLastResult] will include the value of the last successful execution in all [CommandResult] events unless there is no new result.
-  /// By default the [results] Observable and the [RxCommand] itself behave like a PublishSubject. If you want that it acts like
-  /// a BehaviourSubject, meaning every new listener gets the last received value, you can set [emitsLastValueToNewSubscriptions = true].
-  /// [initialLastResult] sets the value of the [lastResult] property before the first item was received. This is helpful if you use
-  /// [lastResult] as `initialData` of a `StreamBuilder`
-  static RxCommand<void, TResult> createAsyncNoParam<TResult>(AsyncFunc<TResult> func,
-      {Observable<bool> canExecute,
-      bool emitInitialCommandResult = false,
-      bool emitLastResult = false,
-      bool emitsLastValueToNewSubscriptions = false,
-      TResult initialLastResult}) {
-    return new RxCommandAsync<void, TResult>((_) async => func(), canExecute, emitInitialCommandResult, emitLastResult,
-        emitsLastValueToNewSubscriptions, initialLastResult);
-  }
+  // Asynchronous
 
   /// Creates  a RxCommand for an asynchronous handler function with parameter that returns a value
   /// `func`: handler function

--- a/test/rx_command_test.dart
+++ b/test/rx_command_test.dart
@@ -7,7 +7,7 @@ import 'package:rxdart/rxdart.dart';
 
 StreamMatcher crm<T>(Object data, bool hasError, bool isExceuting) {
   return new StreamMatcher((x) async {
-    final CommandResult<T> event = await x.next as CommandResult<T>;
+    final event = await x.next as CommandResult<T>;
     if (event.data != data) return "Wong data $data != ${event.data}";
 
     if (!hasError && event.error != null) return "Had error while not expected";
@@ -22,7 +22,7 @@ StreamMatcher crm<T>(Object data, bool hasError, bool isExceuting) {
 
 void main() {
   test('Execute simple sync action', () {
-    var command = RxCommand.createSyncNoParamNoResult(() => print("action"));
+    var command = RxCommand.createSync((_) => print("action"));
 
 
     expect(command.canExecute, emits(true));
@@ -38,7 +38,7 @@ void main() {
   });
 
   test('Execute simple sync action with emitInitialCommandResult: true', () {
-    final command = RxCommand.createSyncNoParamNoResult(() => print("action"), emitInitialCommandResult: true);
+    final command = RxCommand.createSync((_) => print("action"), emitInitialCommandResult: true);
 
     command.results.listen((result) => print(result.toString()));
 
@@ -62,7 +62,7 @@ void main() {
 
     var executionCount = 0;
 
-    final command = RxCommand.createSyncNoParamNoResult(() => executionCount++, canExecute: restriction);
+    final command = RxCommand.createSync((_) => executionCount++, canExecute: restriction);
 
     expect(command.canExecute, emits(true));
     expect(command.isExecuting, emits(false));
@@ -93,7 +93,7 @@ void main() {
   });
 
   test('Execute simple sync action with exception  throwExceptions==true', () {
-    final command = RxCommand.createSyncNoParamNoResult(() => throw new Exception("Intentional"))..throwExceptions = true;
+    final command = RxCommand.createSync((_) => throw new Exception("Intentional"))..throwExceptions = true;
 
     expect(command.canExecute, emits(true));
     expect(command.isExecuting, emits(false));
@@ -107,7 +107,7 @@ void main() {
   });
 
   test('Execute simple sync action with exception and throwExceptions==false', () {
-    final command = RxCommand.createSyncNoParamNoResult(() => throw new Exception("Intentional"));
+    final command = RxCommand.createSync((_) => throw new Exception("Intentional"));
 
     expect(command.canExecute, emits(true));
     expect(command.isExecuting, emits(false));
@@ -120,7 +120,7 @@ void main() {
   });
 
   test('Execute simple sync action with parameter', () {
-    final command = RxCommand.createSyncNoResult<String>((x) {
+    final command = RxCommand.createSync((String x) {
       print("action: " + x.toString());
       return null;
     });
@@ -137,7 +137,7 @@ void main() {
   });
 
   test('Execute simple sync function without parameter', () {
-    final command = RxCommand.createSyncNoParam<String>(() {
+    final command = RxCommand.createSync((_) {
       print("action: ");
       return "4711";
     });
@@ -156,7 +156,7 @@ void main() {
   });
 
   test('Execute simple sync function without parameter with lastResult=true', () {
-    final command = RxCommand.createSyncNoParam<String>(() {
+    final command = RxCommand.createSync((_) {
       print("action: ");
       return "4711";
     }, emitLastResult: true);
@@ -208,7 +208,7 @@ void main() {
   test('Execute simple async function with parameter', () async {
     var executionCount = 0;
 
-    final command = RxCommand.createAsyncNoResult<String>((s) async {
+    final command = RxCommand.createAsync((String s) async {
       executionCount++;
       await slowAsyncFunction(s);
     });


### PR DESCRIPTION
We don't really need it, the compiler will infer parameters for us if we give it the proper hints, and it makes the code more verbose - the test case diffs are a good example of how we can use hints in the method instead.

Unfortunately, this is a breaking change so we'll definitely have to SEMVER MAJOR it