### PR TITLE
Nextable RxCommand

### DIFF
--- a/lib/rx_command.dart
+++ b/lib/rx_command.dart
@@ -332,6 +332,9 @@ abstract class RxCommand<TParam, TResult> extends Observable<TResult> {
   /// If no subscription exists the Exception will be rethrown
   Observable<dynamic> get thrownExceptions => _thrownExceptionsSubject;
 
+  /// This property is a utility which allows us to chain RxCommands together.
+  Future<TResult> get next => Observable.merge([this, this.thrownExceptions.cast<TResult>()]).take(1).last;
+
   Subject<CommandResult<TResult>> _commandResultsSubject;
   Subject<TResult> _resultsSubject;
   final BehaviorSubject<bool> _isExecutingSubject = new BehaviorSubject<bool>();

--- a/test/rx_command_test.dart
+++ b/test/rx_command_test.dart
@@ -415,6 +415,35 @@ void main() {
     expect(command.isExecuting, emits(false));
   });
 
+  test("async function should be next'able", () async {
+    final cmd = RxCommand.createAsync((_) async {
+      await Future.delayed(Duration(milliseconds: 1));
+      return 42;
+    });
+
+    cmd.execute();
+    final result = await cmd.next;
+
+    expect(result, 42);
+  });
+
+  test("async functions that throw should be next'able", () async {
+    final cmd = RxCommand.createAsync((_) async {
+      await Future.delayed(Duration(milliseconds: 1));
+      throw Exception("oh no");
+    });
+
+    cmd.execute();
+    var didntThrow = true;
+    try {
+      await cmd.next;
+    } catch (e) {
+      didntThrow = false;
+    }
+
+    expect(didntThrow, false);
+  });
+
   Stream<int> testProvider(int i) async* {
     yield i;
     yield i + 1;


### PR DESCRIPTION
`next` is a new property which lets us await on the next invocation of the command. This is nice on its own, as well as making it easier to chain RxCommands together.

Fixes #16