### PR TITLE
Added factory constructors for CommandResult

### DIFF
--- a/lib/rx_command.dart
+++ b/lib/rx_command.dart
@@ -37,6 +37,12 @@ class CommandResult<T> {
   // ignore: avoid_positional_boolean_parameters
   const CommandResult(this.data, this.error, this.isExecuting);
 
+  factory CommandResult.data(T data)=> CommandResult(data, false, false);
+
+  factory CommandResult.error(dynamic error)=> CommandResult(null, error, false);
+
+  factory CommandResult.isLoading()=> CommandResult(null, false, true);
+
   bool get hasData => data != null;
   bool get hasError => error != null;
 


### PR DESCRIPTION
Sometimes it isn't possible to use RxCommand, but still Command result can be in use. For more handy usage - factories. 

p.s. If the idea is OK - I can refactor entire library and switch normal constructor to factories constructor. Maybe even make default constructor private. 

p.s.s. In description you are saying that for normal flow data and busy  - error should be false (not null). But in real usage you are preferring nulls. I guess nulls should be there and description should be corrected? 