### PR TITLE
OnResult and OnError callback function added to RxCommand

### DIFF
--- a/lib/rx_command.dart
+++ b/lib/rx_command.dart
@@ -634,10 +634,11 @@ class RxCommandAsync<TParam, TResult> extends RxCommand<TParam, TResult> {
             false); // Has to be done because in this case no command result is queued
         _canExecute = !_executionLocked;
         _canExecuteSubject.add(!_executionLocked);
-        if (onError != null) {
-          onError(ErrorResult(error: error, param: param));
-        }
         return;
+      }
+
+      if (onError != null) {
+        onError(ErrorResult(error: error, param: param));
       }
 
       _commandResultsSubject.add(CommandResult<TResult>(


### PR DESCRIPTION
Normally we listen to streams to achieve results and errors. Instead, I think it is more useful to add optional callback functions. So I added two callback functions called OnResult and OnError.

However, when an error occurs, if there is an input parameter, I added an ErrorResult class to access the input parameter.

I'd appreciate it if you check it, thanks.


![image](https://user-images.githubusercontent.com/7986394/87852838-1c50bd80-c90e-11ea-83bd-11140e95c819.png)
