### PR TITLE
Migration to null-safety

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.5"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.5"
+    version: "1.15.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -41,20 +41,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  matcher:
+    dependency: transitive
+    description:
+      name: matcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.6"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
@@ -62,13 +69,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.0"
-  quiver_hashcode:
+  quiver:
     dependency: transitive
     description:
-      name: quiver_hashcode
+      name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   rx_command:
     dependency: "direct main"
     description:
@@ -82,7 +89,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.25.0"
+    version: "0.26.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -95,6 +102,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
+  stack_trace:
+    dependency: transitive
+    description:
+      name: stack_trace
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.10.0"
   string_scanner:
     dependency: transitive
     description:
@@ -115,13 +129,13 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.5"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: any
-  rxdart: ^0.25.0
+  rxdart: ^0.26.0
   rx_command: 
     path: ../
 

--- a/lib/rx_command.dart
+++ b/lib/rx_command.dart
@@ -2,7 +2,7 @@ library rx_command;
 
 import 'dart:async';
 
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 import 'package:rxdart/rxdart.dart';
 
 export 'rx_command_listener.dart';
@@ -29,7 +29,7 @@ typedef StreamProvider<TParam, TResult> = Stream<TResult> Function(TParam param)
 /// 3. When execution finishes: `the result, null, false`
 
 class CommandResult<T> {
-  final T data;
+  final T? data;
   final dynamic error;
   final bool isExecuting;
 
@@ -88,7 +88,7 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
 
   final bool _emitLastResult;
 
-  RxCommand(this._resultsSubject, Stream<bool> canExecuteRestriction, this._emitLastResult,
+  RxCommand(this._resultsSubject, Stream<bool>? canExecuteRestriction, this._emitLastResult,
       this._resultSubjectIsBehaviourSubject, this.lastResult)
       : super(_resultsSubject) {
     _commandResultsSubject = _resultSubjectIsBehaviourSubject
@@ -128,7 +128,7 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   /// By default the [results] Observable and the [RxCommand] itself behave like a PublishSubject. If you want that it acts like
   /// a BehaviourSubject, meaning every listener gets the last received value, you can set [emitsLastValueToNewSubscriptions = true].
   static RxCommand<void, void> createSyncNoParamNoResult(Action action,
-      {Stream<bool> canExecute, bool emitInitialCommandResult = false, bool emitsLastValueToNewSubscriptions = false}) {
+      {Stream<bool>? canExecute, bool emitInitialCommandResult = false, bool emitsLastValueToNewSubscriptions = false}) {
     return RxCommandSync<void, void>((_) {
       action();
       return null;
@@ -147,7 +147,7 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   /// By default the [results] Observable and the [RxCommand] itself behave like a PublishSubject. If you want that it acts like
   /// a BehaviourSubject, meaning every listener gets the last received value, you can set [emitsLastValueToNewSubscriptions = true].
   static RxCommand<TParam, void> createSyncNoResult<TParam>(Action1<TParam> action,
-      {Stream<bool> canExecute, bool emitInitialCommandResult = false, bool emitsLastValueToNewSubscriptions = false}) {
+      {Stream<bool>? canExecute, bool emitInitialCommandResult = false, bool emitsLastValueToNewSubscriptions = false}) {
     return RxCommandSync<TParam, void>((x) {
       action(x);
       return null;
@@ -169,11 +169,11 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   /// [initialLastResult] sets the value of the [lastResult] property before the first item was received. This is helpful if you use
   /// [lastResult] as `initialData` of a `StreamBuilder`
   static RxCommand<void, TResult> createSyncNoParam<TResult>(Func<TResult> func,
-      {Stream<bool> canExecute,
+      {Stream<bool>? canExecute,
       bool emitInitialCommandResult = false,
       bool emitLastResult = false,
       bool emitsLastValueToNewSubscriptions = false,
-      TResult initialLastResult}) {
+      TResult? initialLastResult}) {
     return RxCommandSync<void, TResult>((_) => func(), canExecute, emitInitialCommandResult, emitLastResult,
         emitsLastValueToNewSubscriptions, initialLastResult);
   }
@@ -193,11 +193,11 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   /// [initialLastResult] sets the value of the [lastResult] property before the first item was received. This is helpful if you use
   /// [lastResult] as `initialData` of a `StreamBuilder`
   static RxCommand<TParam, TResult> createSync<TParam, TResult>(Func1<TParam, TResult> func,
-      {Stream<bool> canExecute,
+      {Stream<bool>? canExecute,
       bool emitInitialCommandResult = false,
       bool emitLastResult = false,
       bool emitsLastValueToNewSubscriptions = false,
-      TResult initialLastResult}) {
+      TResult? initialLastResult}) {
     return RxCommandSync<TParam, TResult>((x) => func(x), canExecute, emitInitialCommandResult, emitLastResult,
         emitsLastValueToNewSubscriptions, initialLastResult);
   }
@@ -216,7 +216,7 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   /// By default the [results] Observable and the [RxCommand] itself behave like a PublishSubject. If you want that it acts like
   /// a BehaviourSubject, meaning every listener gets the last received value, you can set [emitsLastValueToNewSubscriptions = true].
   static RxCommand<void, void> createAsyncNoParamNoResult(AsyncAction action,
-      {Stream<bool> canExecute, bool emitInitialCommandResult = false, bool emitsLastValueToNewSubscriptions = false}) {
+      {Stream<bool>? canExecute, bool emitInitialCommandResult = false, bool emitsLastValueToNewSubscriptions = false}) {
     return RxCommandAsync<void, void>((_) async {
       await action();
       return null;
@@ -235,7 +235,7 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   /// By default the [results] Observable and the [RxCommand] itself behave like a PublishSubject. If you want that it acts like
   /// a BehaviourSubject, meaning every listener gets the last received value, you can set [emitsLastValueToNewSubscriptions = true].
   static RxCommand<TParam, void> createAsyncNoResult<TParam>(AsyncAction1<TParam> action,
-      {Stream<bool> canExecute, bool emitInitialCommandResult = false, bool emitsLastValueToNewSubscriptions = false}) {
+      {Stream<bool>? canExecute, bool emitInitialCommandResult = false, bool emitsLastValueToNewSubscriptions = false}) {
     return RxCommandAsync<TParam, void>((x) async {
       await action(x);
       return null;
@@ -257,11 +257,11 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   /// [initialLastResult] sets the value of the [lastResult] property before the first item was received. This is helpful if you use
   /// [lastResult] as `initialData` of a `StreamBuilder`
   static RxCommand<void, TResult> createAsyncNoParam<TResult>(AsyncFunc<TResult> func,
-      {Stream<bool> canExecute,
+      {Stream<bool>? canExecute,
       bool emitInitialCommandResult = false,
       bool emitLastResult = false,
       bool emitsLastValueToNewSubscriptions = false,
-      TResult initialLastResult}) {
+      TResult? initialLastResult}) {
     return RxCommandAsync<void, TResult>((_) async => func(), canExecute, emitInitialCommandResult, emitLastResult,
         emitsLastValueToNewSubscriptions, initialLastResult);
   }
@@ -281,11 +281,11 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   /// [initialLastResult] sets the value of the [lastResult] property before the first item was received. This is helpful if you use
   /// [lastResult] as `initialData` of a `StreamBuilder`
   static RxCommand<TParam, TResult> createAsync<TParam, TResult>(AsyncFunc1<TParam, TResult> func,
-      {Stream<bool> canExecute,
+      {Stream<bool>? canExecute,
       bool emitInitialCommandResult = false,
       bool emitLastResult = false,
       bool emitsLastValueToNewSubscriptions = false,
-      TResult initialLastResult}) {
+      TResult? initialLastResult}) {
     return RxCommandAsync<TParam, TResult>((x) async => func(x), canExecute, emitInitialCommandResult, emitLastResult,
         emitsLastValueToNewSubscriptions, initialLastResult);
   }
@@ -305,23 +305,23 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   /// [initialLastResult] sets the value of the [lastResult] property before the first item was received. This is helpful if you use
   /// [lastResult] as `initialData` of a `StreamBuilder`
   static RxCommand<TParam, TResult> createFromStream<TParam, TResult>(StreamProvider<TParam, TResult> provider,
-      {Stream<bool> canExecute,
+      {Stream<bool>? canExecute,
       bool emitInitialCommandResult = false,
       bool emitLastResult = false,
       bool emitsLastValueToNewSubscriptions = false,
-      TResult initialLastResult}) {
+      TResult? initialLastResult}) {
     return RxCommandStream<TParam, TResult>(provider, canExecute, emitInitialCommandResult, emitLastResult,
         emitsLastValueToNewSubscriptions, initialLastResult);
   }
 
   /// Calls the wrapped handler function with an option input parameter
-  void execute([TParam param]);
+  void execute(TParam param);
 
   /// This makes RxCommand a callable class, so instead of `myCommand.execute()` you can write `myCommand()`
-  void call([TParam param]) => execute(param);
+  void call(TParam param) => execute(param);
 
   /// The result of the last successful call to execute. This is especially handy to use as `initialData` of Flutter `StreamBuilder`
-  TResult lastResult;
+  TResult? lastResult;
 
   /// emits [CommandResult<TRESULT>] the combined state of the command, which is often easier in combination with Flutter `StreamBuilder`
   /// because you have all state information at one place.
@@ -342,7 +342,7 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   /// This property is a utility which allows us to chain RxCommands together.
   Future<TResult> get next => Rx.merge([this, this.thrownExceptions.cast<TResult>()]).take(1).last;
 
-  Subject<CommandResult<TResult>> _commandResultsSubject;
+  late Subject<CommandResult<TResult>> _commandResultsSubject;
   final Subject<TResult> _resultsSubject;
   final BehaviorSubject<bool> _isExecutingSubject = BehaviorSubject<bool>();
   final BehaviorSubject<bool> _canExecuteSubject = BehaviorSubject<bool>();
@@ -368,8 +368,8 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
 class RxCommandSync<TParam, TResult> extends RxCommand<TParam, TResult> {
   Func1<TParam, TResult> _func;
 
-  factory RxCommandSync(Func1<TParam, TResult> func, Stream<bool> canExecute, bool emitInitialCommandResult,
-      bool emitLastResult, bool emitsLastValueToNewSubscriptions, TResult initialLastResult) {
+  factory RxCommandSync(Func1<TParam, TResult> func, Stream<bool>? canExecute, bool emitInitialCommandResult,
+      bool emitLastResult, bool emitsLastValueToNewSubscriptions, TResult? initialLastResult) {
     return RxCommandSync._(
         func,
         emitsLastValueToNewSubscriptions || emitInitialCommandResult
@@ -382,8 +382,8 @@ class RxCommandSync<TParam, TResult> extends RxCommand<TParam, TResult> {
         initialLastResult);
   }
 
-  RxCommandSync._(Func1<TParam, TResult> func, Subject<TResult> subject, Stream<bool> canExecute, bool buffer,
-      bool isBehaviourSubject, bool emitInitialCommandResult, TResult initialLastResult)
+  RxCommandSync._(Func1<TParam, TResult> func, Subject<TResult> subject, Stream<bool>? canExecute, bool buffer,
+      bool isBehaviourSubject, bool emitInitialCommandResult, TResult? initialLastResult)
       : _func = func,
         super(subject, canExecute, buffer, isBehaviourSubject, initialLastResult) {
     if (emitInitialCommandResult) {
@@ -392,7 +392,7 @@ class RxCommandSync<TParam, TResult> extends RxCommand<TParam, TResult> {
   }
 
   @override
-  void execute([TParam param]) {
+  void execute(TParam param) {
     if (!_canExecute) {
       return;
     }
@@ -431,8 +431,8 @@ class RxCommandSync<TParam, TResult> extends RxCommand<TParam, TResult> {
 class RxCommandAsync<TParam, TResult> extends RxCommand<TParam, TResult> {
   AsyncFunc1<TParam, TResult> _func;
 
-  RxCommandAsync._(AsyncFunc1<TParam, TResult> func, Subject<TResult> subject, Stream<bool> canExecute,
-      bool emitLastResult, bool isBehaviourSubject, bool emitInitialCommandResult, TResult initialLastResult)
+  RxCommandAsync._(AsyncFunc1<TParam, TResult> func, Subject<TResult> subject, Stream<bool>? canExecute,
+      bool emitLastResult, bool isBehaviourSubject, bool emitInitialCommandResult, TResult? initialLastResult)
       : _func = func,
         super(subject, canExecute, emitLastResult, isBehaviourSubject, initialLastResult) {
     if (emitInitialCommandResult) {
@@ -440,8 +440,8 @@ class RxCommandAsync<TParam, TResult> extends RxCommand<TParam, TResult> {
     }
   }
 
-  factory RxCommandAsync(AsyncFunc1<TParam, TResult> func, Stream<bool> canExecute, bool emitInitialCommandResult,
-      bool emitLastResult, bool emitsLastValueToNewSubscriptions, TResult initialLastResult) {
+  factory RxCommandAsync(AsyncFunc1<TParam, TResult> func, Stream<bool>? canExecute, bool emitInitialCommandResult,
+      bool emitLastResult, bool emitsLastValueToNewSubscriptions, TResult? initialLastResult) {
     return RxCommandAsync._(
         func,
         emitsLastValueToNewSubscriptions || emitInitialCommandResult
@@ -455,7 +455,7 @@ class RxCommandAsync<TParam, TResult> extends RxCommand<TParam, TResult> {
   }
 
   @override
-  execute([TParam param]) {
+  execute(TParam param) {
     //print("************ Execute***** canExecute: $_canExecute ***** isExecuting: $_isRunning");
 
     if (!_canExecute) {
@@ -471,7 +471,7 @@ class RxCommandAsync<TParam, TResult> extends RxCommand<TParam, TResult> {
 
     _commandResultsSubject.add(CommandResult<TResult>(_emitLastResult ? lastResult : null, null, true));
 
-    _func(param).asStream().handleError((error) {
+    _func(param).asStream().handleError((Function error) {
       if (throwExceptions) {
         _resultsSubject.addError(error);
         _commandResultsSubject.addError(error);
@@ -500,16 +500,16 @@ class RxCommandAsync<TParam, TResult> extends RxCommand<TParam, TResult> {
 class RxCommandStream<TParam, TResult> extends RxCommand<TParam, TResult> {
   StreamProvider<TParam, TResult> _observableProvider;
 
-  StreamSubscription<Notification<TResult>> _inputStreamSubscription;
+  StreamSubscription<Notification<TResult>>? _inputStreamSubscription;
 
   RxCommandStream._(
       StreamProvider<TParam, TResult> provider,
       Subject<TResult> subject,
-      Stream<bool> canExecute,
+      Stream<bool>? canExecute,
       bool emitLastResult,
       bool isBehaviourSubject,
       bool emitInitialCommandResult,
-      TResult initialLastResult)
+      TResult? initialLastResult)
       : _observableProvider = provider,
         super(subject, canExecute, emitLastResult, isBehaviourSubject, initialLastResult) {
     if (emitInitialCommandResult) {
@@ -519,11 +519,11 @@ class RxCommandStream<TParam, TResult> extends RxCommand<TParam, TResult> {
 
   factory RxCommandStream(
       StreamProvider<TParam, TResult> provider,
-      Stream<bool> canExecute,
+      Stream<bool>? canExecute,
       bool emitInitialCommandResult,
       bool emitLastResult,
       bool emitsLastValueToNewSubscriptions,
-      TResult initialLastResult) {
+      TResult? initialLastResult) {
     return RxCommandStream._(
         provider,
         emitsLastValueToNewSubscriptions || emitInitialCommandResult
@@ -537,7 +537,7 @@ class RxCommandStream<TParam, TResult> extends RxCommand<TParam, TResult> {
   }
 
   @override
-  execute([TParam param]) {
+  execute(TParam param) {
     if (!_canExecute) {
       return;
     }
@@ -556,15 +556,15 @@ class RxCommandStream<TParam, TResult> extends RxCommand<TParam, TResult> {
     _inputStreamSubscription = inputStream.materialize().listen(
       (notification) {
         if (notification.isOnData) {
-          _resultsSubject.add(notification.value);
-          _commandResultsSubject.add(CommandResult(notification.value, null, true));
-          lastResult = notification.value;
+          _resultsSubject.add(notification.requireData);
+          _commandResultsSubject.add(CommandResult(notification.requireData, null, true));
+          lastResult = notification.requireData;
         } else if (notification.isOnError) {
           if (throwExceptions) {
-            _resultsSubject.addError(notification.errorAndStackTrace.error);
-            _commandResultsSubject.addError(notification.errorAndStackTrace.error);
+            _resultsSubject.addError(notification.errorAndStackTrace?.error as Object);
+            _commandResultsSubject.addError(notification.errorAndStackTrace?.error as Object);
           } else {
-            _commandResultsSubject.add(CommandResult<TResult>(null, notification.errorAndStackTrace.error, false));
+            _commandResultsSubject.add(CommandResult<TResult>(null, notification.errorAndStackTrace?.error as Object, false));
           }
         } else if (notification.isOnDone) {
           _commandResultsSubject.add(CommandResult(lastResult, null, false));
@@ -588,32 +588,36 @@ class RxCommandStream<TParam, TResult> extends RxCommand<TParam, TResult> {
 /// `MockCommand` allows you to easily mock an RxCommand for your Unit and UI tests
 /// Mocking a command with `mockito` https://pub.dartlang.org/packages/mockito has its limitations.
 class MockCommand<TParam, TResult> extends RxCommand<TParam, TResult> {
-  List<CommandResult<TResult>> returnValuesForNextExecute;
+  List<CommandResult<TResult>>? returnValuesForNextExecute;
 
   /// the last value that was passed when execute or the command directly was called
-  TParam lastPassedValueToExecute;
+  TParam? lastPassedValueToExecute;
 
   /// Number of times execute or the command directly was called
   int executionCount = 0;
 
   /// Factory constructor that can take an optional observable to control if the command can be executet
   factory MockCommand(
-      {Stream<bool> canExecute,
+      {Stream<bool>? canExecute,
       bool emitInitialCommandResult = false,
       bool emitLastResult = false,
       bool emitsLastValueToNewSubscriptions = false,
-      TResult initialLastResult}) {
+      TResult? initialLastResult}) {
     return MockCommand._(emitsLastValueToNewSubscriptions ? BehaviorSubject<TResult>() : PublishSubject<TResult>(),
         canExecute, emitLastResult, false, emitInitialCommandResult, initialLastResult);
   }
 
-  MockCommand._(Subject<TResult> subject, Stream<bool> canExecute, bool emitLastResult, bool isBehaviourSubject,
-      bool emitInitialCommandResult, TResult initialLastResult)
+  MockCommand._( Subject<TResult> subject, Stream<bool>? canExecute, bool emitLastResult, bool isBehaviourSubject,
+      bool emitInitialCommandResult, TResult? initialLastResult)
       : super(subject, canExecute, emitLastResult, isBehaviourSubject, initialLastResult) {
     if (emitInitialCommandResult) {
       _commandResultsSubject.add(CommandResult<TResult>(null, null, false));
     }
-    _commandResultsSubject.where((result) => result.hasData).listen((result) => _resultsSubject.add(result.data));
+    _commandResultsSubject.where((result) => result.hasData).listen((result) {
+      if (result.data != null) {
+        _resultsSubject.add(result.data!);
+      }
+    });
   }
 
   /// to be able to simulate any output of the command when it is called you can here queue the output data for the next exeution call
@@ -626,14 +630,14 @@ class MockCommand<TParam, TResult> extends RxCommand<TParam, TResult> {
   /// If you have queued a result with [queueResultsForNextExecuteCall] it will be copies tho the output stream.
   /// [isExecuting], [canExecute] and [results] will work as with a real command.
   @override
-  execute([TParam param]) {
+  execute(TParam param) {
     _canExecuteSubject.add(false);
     executionCount++;
     lastPassedValueToExecute = param;
     print("Called Execute");
     if (returnValuesForNextExecute != null) {
       _commandResultsSubject.addStream(
-        Stream<CommandResult<TResult>>.fromIterable(returnValuesForNextExecute)
+        Stream<CommandResult<TResult>>.fromIterable(returnValuesForNextExecute!)
             .map(
           (data) {
             if ((data.isExecuting || data.hasError) && _emitLastResult) {

--- a/lib/rx_command_listener.dart
+++ b/lib/rx_command_listener.dart
@@ -1,31 +1,32 @@
 import 'dart:async';
-import 'package:rxdart/rxdart.dart';
+
 import 'package:rx_command/rx_command.dart';
+import 'package:rxdart/rxdart.dart';
 
 class RxCommandListener<TParam, TResult> {
-  StreamSubscription<TResult> valueSubscription;
-  StreamSubscription<CommandResult> resultsSubscription;
-  StreamSubscription<bool> busyChangeSubscription;
-  StreamSubscription<bool> busySubscription;
-  StreamSubscription errorSubscription;
-  StreamSubscription<bool> canExecuteStateSubscription;
+  StreamSubscription<TResult?>? valueSubscription;
+  StreamSubscription<CommandResult>? resultsSubscription;
+  StreamSubscription<bool>? busyChangeSubscription;
+  StreamSubscription<bool>? busySubscription;
+  StreamSubscription? errorSubscription;
+  StreamSubscription<bool>? canExecuteStateSubscription;
 
   final RxCommand<TParam, TResult> command;
 
   // Is called on every emitted value of the command
-  final void Function(TResult value) onValue;
+  final void Function(TResult? value)? onValue;
   // Is called when isExecuting changes
-  final void Function(bool isBusy) onIsBusyChange;
+  final void Function(bool isBusy)? onIsBusyChange;
   // Is called on exceptions in the wrapped command function
-  final void Function(dynamic ex) onError;
+  final void Function(dynamic ex)? onError;
   // Is called when canExecute changes
-  final void Function(bool state) onCanExecuteChange;
+  final void Function(bool state)? onCanExecuteChange;
   // is called with the value of the .results Stream of the command
-  final void Function(CommandResult<TResult> result) onResult;
+  final void Function(CommandResult<TResult> result)? onResult;
 
   // to make the handling of busy states even easier these are called on their respective states
-  final void Function() onIsBusy;
-  final void Function() onNotBusy;
+  final void Function()? onIsBusy;
+  final void Function()? onNotBusy;
 
   // optional you can directly pass in a debounce duration for the values of the command
   final Duration debounceDuration;
@@ -39,9 +40,9 @@ class RxCommandListener<TParam, TResult> {
     this.onError,
     this.onCanExecuteChange,
     this.onResult,
-    this.debounceDuration,
+    this.debounceDuration = const Duration(seconds: 0),
   }) {
-    if (debounceDuration == null) {
+    if (debounceDuration.inMicroseconds == 0) {
       if (onValue != null) {
         valueSubscription = command.listen(onValue);
       }
@@ -62,7 +63,7 @@ class RxCommandListener<TParam, TResult> {
       if (onValue != null) {
         valueSubscription =
             command.debounceTime(debounceDuration).listen(onValue);
-        if (onResult != null && debounceDuration != null) {
+        if (onResult != null) {
           resultsSubscription =
               command.results.debounceTime(debounceDuration).listen(onResult);
         }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,21 +28,21 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   cli_util:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
@@ -92,13 +92,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -133,7 +126,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3"
   logging:
     dependency: transitive
     description:
@@ -147,14 +140,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.9"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.4"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
@@ -196,21 +189,21 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.11.0"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
@@ -219,26 +212,19 @@ packages:
     source: hosted
     version: "1.4.4"
   quiver:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
-  quiver_hashcode:
-    dependency: "direct main"
-    description:
-      name: quiver_hashcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   rxdart:
     dependency: "direct main"
     description:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.25.0"
+    version: "0.26.0"
   shelf:
     dependency: transitive
     description:
@@ -273,77 +259,77 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.6"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.7"
+    version: "1.16.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.18+1"
+    version: "0.2.19"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.11+4"
+    version: "0.3.15"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
@@ -380,4 +366,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.9.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,11 +11,10 @@ environment:
   sdk: '>=2.6.1 <3.0.0'
 
 dependencies:
-  rxdart: ^0.25.0
-  quiver_hashcode: ^2.0.0
+  rxdart: ^0.26.0
+  quiver: ^3.0.0
 
 
 dev_dependencies:
   test: any
-  quiver: ^2.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ authors:
 homepage: https://github.com/fluttercommunity/rx_command
 documentation:
 environment:
-  sdk: '>=2.6.1 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   rxdart: ^0.26.0


### PR DESCRIPTION
Hi all,

I have put together an initial PR for migrating the package to null-safety. However, I can't seem to find a way to migrate the package in a way that this

```dart
late RxCommand<void, void> myCommand;

[...]

RxCommand.createSyncNoParamNoResult(_myFunc)

[...]

void _myFunc() {}

[...]

myCommand();
myCommand.execute();
```

It's related to these two lines:

```dart
  /// Calls the wrapped handler function with an option input parameter
  void execute(TParam param);

  /// This makes RxCommand a callable class, so instead of `myCommand.execute()` you can write `myCommand()`
  void call(TParam param) => execute(param);
```

which used to be


```dart
  /// Calls the wrapped handler function with an option input parameter
  void execute([TParam param]);

  /// This makes RxCommand a callable class, so instead of `myCommand.execute()` you can write `myCommand()`
  void call([TParam param]) => execute(param);
```

I have therefore not updated the tests and demo application yet.

May I kindly request you to review and amend as necessary.

Thank you!