### PR TITLE
Update quiver hashcode dependency

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.5"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.5"
+    version: "1.15.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -41,13 +41,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  matcher:
+    dependency: transitive
+    description:
+      name: matcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.12.9"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.6"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
@@ -62,13 +69,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.0"
-  quiver_hashcode:
+  quiver:
     dependency: transitive
     description:
-      name: quiver_hashcode
+      name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.5"
   rx_command:
     dependency: "direct main"
     description:
@@ -95,6 +102,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
+  stack_trace:
+    dependency: transitive
+    description:
+      name: stack_trace
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.9.6"
   string_scanner:
     dependency: transitive
     description:
@@ -115,13 +129,13 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.5"
+    version: "2.1.0"
 sdks:
   dart: ">=2.12.0-0 <3.0.0"

--- a/lib/rx_command.dart
+++ b/lib/rx_command.dart
@@ -2,7 +2,7 @@ library rx_command;
 
 import 'dart:async';
 
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 import 'package:rxdart/rxdart.dart';
 
 export 'rx_command_listener.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -219,19 +219,12 @@ packages:
     source: hosted
     version: "1.4.4"
   quiver:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
-  quiver_hashcode:
-    dependency: "direct main"
-    description:
-      name: quiver_hashcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   rxdart:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,10 +12,9 @@ environment:
 
 dependencies:
   rxdart: ^0.25.0
-  quiver_hashcode: ^2.0.0
+  quiver: ^2.0.0
 
 
 dev_dependencies:
   test: any
-  quiver: ^2.0.0
 


### PR DESCRIPTION
Development on the quiver_* subpackages has been discontinued in favour
of the main quiver package at https://github.com/~/quiver-dart. The
code itself is identical, but is more actively maintained.

This migrates to version 2.0.0 of quiver since version 3.0.0 has been
migrated to null-safety, which requires Dart SDK 2.12.0 or Flutter
2.0.0.