### PR TITLE
Made param in action-typedefs non-nullable

### DIFF
--- a/lib/rx_command.dart
+++ b/lib/rx_command.dart
@@ -8,16 +8,16 @@ import 'package:rxdart/rxdart.dart';
 export 'rx_command_listener.dart';
 
 typedef Action = void Function();
-typedef Action1<TParam> = void Function(TParam? param);
+typedef Action1<TParam> = void Function(TParam param);
 
 typedef Func<TResult> = TResult Function();
 typedef Func1<TParam, TResult> = TResult Function(TParam param);
 
 typedef AsyncAction = Future Function();
-typedef AsyncAction1<TParam> = Future Function(TParam? param);
+typedef AsyncAction1<TParam> = Future Function(TParam param);
 
 typedef AsyncFunc<TResult> = Future<TResult> Function();
-typedef AsyncFunc1<TParam, TResult> = Future<TResult> Function(TParam? param);
+typedef AsyncFunc1<TParam, TResult> = Future<TResult> Function(TParam param);
 
 typedef StreamProvider<TParam, TResult> = Stream<TResult> Function(
     TParam? param);

--- a/test/rx_command_test.dart
+++ b/test/rx_command_test.dart
@@ -210,7 +210,7 @@ void main() {
 
   test('Execute simple sync function with parameter', () {
     final command = RxCommand.createSync<String, String>((s) {
-      print("action: " + s!);
+      print("action: " + s);
       return s + s;
     }, initialLastResult: '');
 
@@ -647,6 +647,24 @@ void main() {
     await Future.delayed(Duration(seconds: 1));
 
     expect(count, 1);
+  });
+
+  Future<String?> _f1 (String s) async {
+    return Future.value(s);
+  }
+  Future<String?> _f2 (String s) async {
+    return Future.value(null);
+  }
+
+  test('Nullability test', () async {
+
+    final command1 = RxCommand.createAsync<String, String?>(_f1);
+    expect(command1, emits("Non-nullable string"));
+    command1.execute("Non-nullable string");
+
+    final command2 = RxCommand.createAsync<String, String?>(_f2);
+    expect(command2, emits(null));
+    command2.execute("Non-nullable string");
   });
 
 // No idea why it's not posible to catch the exception with     expect(command.results, emitsError(isException));


### PR DESCRIPTION
PR to turn action typedefs non-nullable as per #47.

Manual tests have worked as expected.

I have additionally tested via

```dart
  Future<String?> _f1 (String s) async {
    return Future.value(s);
  }
  Future<String?> _f2 (String s) async {
    return Future.value(null);
  }

  test('Nullability test', () async {

    final command1 = RxCommand.createAsync<String, String?>(_f1);
    expect(command1, emits("Non-nullable string"));
    command1.execute("Non-nullable string");

    final command2 = RxCommand.createAsync<String, String?>(_f2);
    expect(command2, emits(null));
    command2.execute("Non-nullable string");
  });
```

I have added the above test code, too, although it may very well be redundant....