### PR TITLE
Made TResult of StreamView non-nullable

### DIFF
--- a/lib/rx_command.dart
+++ b/lib/rx_command.dart
@@ -533,8 +533,8 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
       loggingHandler;
 
   /// This property is a utility which allows us to chain RxCommands together.
-  Future<TResult?> get next =>
-      Rx.merge<TResult?>([this, this.thrownExceptions.cast<TResult>()])
+  Future<TResult> get next =>
+      Rx.merge<TResult>([this, this.thrownExceptions.cast<TResult>()])
           .take(1)
           .last;
 

--- a/lib/rx_command.dart
+++ b/lib/rx_command.dart
@@ -115,7 +115,7 @@ class CommandError<TParam> {
 /// where [TParam] is the type of data that is passed when calling [execute] and
 /// [TResult] denotes the return type of the handler function. To signal that
 /// a handler doesn't take a parameter or returns no value use the type `void`
-abstract class RxCommand<TParam, TResult> extends StreamView<TResult?> {
+abstract class RxCommand<TParam, TResult> extends StreamView<TResult> {
   bool _isRunning = false;
   bool _canExecute = true;
   bool _executionLocked = false;
@@ -539,7 +539,7 @@ abstract class RxCommand<TParam, TResult> extends StreamView<TResult?> {
           .last;
 
   late Subject<CommandResult<TParam, TResult>> _commandResultsSubject;
-  final Subject<TResult?> _resultsSubject;
+  final Subject<TResult> _resultsSubject;
   final BehaviorSubject<bool> _isExecutingSubject = BehaviorSubject<bool>();
   final BehaviorSubject<bool> _canExecuteSubject = BehaviorSubject<bool>();
   final PublishSubject<CommandError<TParam>> _thrownExceptionsSubject =
@@ -657,7 +657,9 @@ class RxCommandSync<TParam, TResult> extends RxCommand<TParam, TResult> {
         result = null;
       }
       lastResult = result;
-      _resultsSubject.add(result);
+      if (result != null || null is TResult) {
+      _resultsSubject.add(result as TResult);
+      }
       commandResult =
           CommandResult<TParam, TResult>(param, result, null, false);
       _commandResultsSubject.add(commandResult);

--- a/test/rx_command_test.dart
+++ b/test/rx_command_test.dart
@@ -667,6 +667,19 @@ void main() {
     command2.execute("Non-nullable string");
   });
 
+  
+  test("Nullability test for next'able", () async {
+    final cmd = RxCommand.createAsyncNoParam<int>(() async {
+      await Future.delayed(Duration(milliseconds: 1000));
+      return 42;
+    }, initialLastResult: 0);
+
+    cmd.execute();
+    final result = await cmd.next is int;
+
+    expect(result, true);
+  });
+
 // No idea why it's not posible to catch the exception with     expect(command.results, emitsError(isException));
 /*
     test('RxCommand.createFromStreamWithException throw exeption = true', () 


### PR DESCRIPTION
I believe a nullable TResult for StreamView to be incorrect. Example with the following command:

```dart
RxCommand<bool, bool> command = RxCommand.createSync<bool,bool>(_f)
```
Setting up non-nullable TParam & TResult would still give you this:

```dart
await command.first;
// Results in Future<bool?> 

command.listen(_f);
// Results in StreamSubscription<bool?>
```

I.e. despite the non-nullable setup, it would still give you nullable results....

